### PR TITLE
Allow overriding HOSTNAME env var

### DIFF
--- a/templates/deployment.yml
+++ b/templates/deployment.yml
@@ -93,14 +93,27 @@ spec:
           {{- end }}
           resources: {{- toYaml .Values.resources | nindent 12 }}
           env:
-            {{- if .Values.environment }}
-            {{- toYaml .Values.environment | nindent 12 }}
+            {{- $shouldInjectHostname := true }}
+            {{- range .Values.environment }}
+            {{- if eq .name "HOSTNAME" }}
+            {{- $shouldInjectHostname = false }}
             {{- end }}
+            - name: {{ .name }}
+            {{- if .value }}
+              value: {{ .value }}
+            {{- end }}
+            {{- if .valueFrom }}
+              valueFrom: 
+            {{- toYaml .valueFrom | nindent 16 }}
+            {{- end }}
+            {{- end }}
+            {{- if $shouldInjectHostname }}
             - name: HOSTNAME
               valueFrom:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: status.podIP
+            {{- end }}
             - name: LICENSE
               valueFrom:
                 secretKeyRef:

--- a/values.yaml
+++ b/values.yaml
@@ -271,8 +271,12 @@ disruptionBudget:
 ## to use the Kubernetes secrets implementation.
 ##
 ## ref: https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/
-## @param environment [object] Extra env vars passed to the Horizon pods
-environment: {}
+## @param environment Extra env vars passed to the Horizon pods
+## eg.
+##   environment:
+##     - name: KEY
+##       value: VALUE
+environment: []
 
 ## Pod's DNS Configuration
 ## https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-dns-config


### PR DESCRIPTION
Allow overriding HOSTNAME to set arbitrary artery canonical addresses, for cross-cluster clustering to work properly.

https://doc.akka.io/docs/akka/current/remoting-artery.html#canonical-address