### PR TITLE
Add selector label for Helm Release

### DIFF
--- a/config/akka.conf
+++ b/config/akka.conf
@@ -31,7 +31,7 @@ akka {
   discovery {
     kubernetes-api {
       pod-namespace = "{{ .Release.Namespace }}"
-      pod-label-selector = "app.kubernetes.io/name={{ include "common.names.name" . }}"
+      pod-label-selector = "app.kubernetes.io/name={{ include "common.names.name" . }},app.kubernetes.io/instance={{ .Release.Name }}"
     }
   }
   management {

--- a/templates/deployment.yml
+++ b/templates/deployment.yml
@@ -114,6 +114,11 @@ spec:
                   apiVersion: v1
                   fieldPath: status.podIP
             {{- end }}
+            # Inject the actor system name from the Helm release name
+            - name: AKKA_ACTOR_SYSTEM
+              valueFrom:
+                fieldRef:
+                  fieldPath : metadata.labels['app.kubernetes.io/instance']
             - name: LICENSE
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
This PR allows multiple actor systems to be installed in the same namespace without colliding, by injecting the Akka actor system name from the `app.kubernetes.io/instance` annotations, uniquely identifying each release.