### PR TITLE
Better annotations and label handling

### DIFF
--- a/templates/config.yml
+++ b/templates/config.yml
@@ -3,8 +3,11 @@ kind: ConfigMap
 metadata:
   name: {{ printf "%s-config" (include "common.names.fullname" $) }}
   labels: {{- include "horizon.labels.standard" . | nindent 4 }}
-    {{- if .Values.commonLabels }}
-    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- if .Values.commonLabels }}
+  {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 data:
 {{ tpl (.Files.Glob "config/*").AsConfig . | indent 2 }}

--- a/templates/deployment.yml
+++ b/templates/deployment.yml
@@ -6,21 +6,36 @@ metadata:
   {{- if .Values.commonLabels }}
   {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
   {{- end }}
+  {{- if or .Values.commonAnnotations .Values.deploymentAnnotations }}
+  annotations: 
+  {{- if .Values.deploymentAnnotations }}
+  {{- include "common.tplvalues.render" ( dict "value" .Values.deploymentAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+  {{- if .Values.commonAnnotations }}
+  {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+  {{- end }}
 spec:
-  {{ if .Values.horizontalAutoscaler.enabled }}
+  {{- if .Values.horizontalAutoscaler.enabled }}
   replicas: {{ .Values.horizontalAutoscaler.minReplicas }}
-  {{ end }}
+  {{- end }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
   strategy: {{- include "common.tplvalues.render" (dict "value" .Values.updateStrategy "context" $ ) | nindent 4 }}
   template:
     metadata:
       labels: {{- include "horizon.labels.standard" . | nindent 8 }}
+        {{- if .Values.commonLabels }}
+        {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 8 }}
+        {{- end }}
         {{- if .Values.podLabels }}
         {{- include "common.tplvalues.render" (dict "value" .Values.podLabels "context" $) | nindent 8 }}
         {{- end }}
       annotations:
         checksum/config: {{ tpl (.Files.Glob "config/*").AsConfig . | sha256sum }}
+        {{- if .Values.commonAnnotations }}
+        {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 8 }}
+        {{- end }}
         {{- if .Values.podAnnotations }}
         {{- include "common.tplvalues.render" (dict "value" .Values.podAnnotations "context" $) | nindent 8 }}
         {{- end }}

--- a/templates/deployment.yml
+++ b/templates/deployment.yml
@@ -6,6 +6,9 @@ metadata:
   {{- if .Values.commonLabels }}
   {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
   {{- end }}
+  {{- if .Values.deploymentLabels }}
+  {{- include "common.tplvalues.render" ( dict "value" .Values.deploymentLabels "context" $ ) | nindent 4 }}
+  {{- end }}
   {{- if or .Values.commonAnnotations .Values.deploymentAnnotations }}
   annotations: 
   {{- if .Values.deploymentAnnotations }}

--- a/templates/monitor.yml
+++ b/templates/monitor.yml
@@ -4,8 +4,11 @@ kind: ServiceMonitor
 metadata:
   name: {{ template "common.names.fullname" . }}
   labels: {{- include "horizon.labels.standard" . | nindent 4 }}
-    {{- if .Values.commonLabels }}
+  {{- if .Values.commonLabels }}
   {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
   endpoints:

--- a/templates/rbac.yml
+++ b/templates/rbac.yml
@@ -3,6 +3,13 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ template "common.names.fullname" . }}-lease-updater
+  labels: {{- include "horizon.labels.standard" . | nindent 4 }}
+  {{- if .Values.commonLabels }}
+  {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 rules:
   - apiGroups: [ "akka.io" ]
     resources: [ "leases" ]
@@ -12,6 +19,13 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ template "common.names.fullname" . }}-lease-updater
+  labels: {{- include "horizon.labels.standard" . | nindent 4 }}
+  {{- if .Values.commonLabels }}
+  {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 subjects:
   - kind: ServiceAccount
     name: default
@@ -26,6 +40,13 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ template "common.names.fullname" . }}-pod-reader
+  labels: {{- include "horizon.labels.standard" . | nindent 4 }}
+  {{- if .Values.commonLabels }}
+  {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 rules:
   - apiGroups: [ "" ]
     resources: [ "pods" ]
@@ -35,6 +56,13 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ template "common.names.fullname" . }}-pod-reader
+  labels: {{- include "horizon.labels.standard" . | nindent 4 }}
+  {{- if .Values.commonLabels }}
+  {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 subjects:
   - kind: ServiceAccount
     name: default

--- a/templates/secrets.yml
+++ b/templates/secrets.yml
@@ -8,6 +8,9 @@ metadata:
   {{- if .Values.commonLabels }}
   {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
   {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 type: Opaque
 data:
   {{- if not .Values.appSecret }}

--- a/templates/upgrade.yml
+++ b/templates/upgrade.yml
@@ -3,6 +3,13 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ printf "%s-upgrade-%s" (include "common.names.fullname" $) (randAlphaNum 6 | lower) }}
+  labels: {{- include "horizon.labels.standard" . | nindent 4 }}
+  {{- if .Values.commonLabels }}
+  {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 spec:
   template:
     spec:

--- a/values.yaml
+++ b/values.yaml
@@ -78,6 +78,10 @@ updateStrategy:
 ##
 deploymentAnnotations: {}
 
+## @param deploymentAnnotations Annotations to add to the deployment object
+##
+deploymentLabels: {}
+
 ## @param priorityClassName Horizon pod priority class name
 ##
 priorityClassName: ""

--- a/values.yaml
+++ b/values.yaml
@@ -74,6 +74,10 @@ image:
 updateStrategy:
   type: Recreate
 
+## @param deploymentAnnotations Annotations to add to the deployment object
+##
+deploymentAnnotations: {}
+
 ## @param priorityClassName Horizon pod priority class name
 ##
 priorityClassName: ""


### PR DESCRIPTION
This PR aims to both:

- add common labels and annotations to every resource created by this chart.
- allow users to specify `deploymentAnnotations` to add annotations and `deploymentLabels` to add labels to their `Deployment` object.
