### PR TITLE
fix: Bump horizon to 2.8.6 and horizon migration to 1.15.0

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,7 +3,7 @@ name: horizon
 description: EverTrust Horizon Helm chart
 type: application
 version: 2.0.12
-appVersion: "2.8.5"
+appVersion: "2.8.6"
 icon: https://evertrust.io/media/logo-horizon-blue.png
 home: https://evertrust.io
 sources:

--- a/values.yaml
+++ b/values.yaml
@@ -56,7 +56,7 @@ commonAnnotations: {}
 image:
   registry: registry.evertrust.io
   repository: horizon
-  tag: 2.8.5
+  tag: 2.8.6
   flavor: ""
   pullPolicy: IfNotPresent
   pullSecrets: []
@@ -761,7 +761,7 @@ upgrade:
   image:
     registry: registry.evertrust.io
     repository: horizon-migration
-    tag: 1.14.0
+    tag: 1.15.0
     pullPolicy: IfNotPresent
     pullSecrets: []
   ## horizon-migration container resource requests and limits


### PR DESCRIPTION
🐛 I have created a release beep boop