### PR TITLE
fix: Bump horizon to 2.9.1 and horizon migration to 1.16.0

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,7 +3,7 @@ name: horizon
 description: EverTrust Horizon Helm chart
 type: application
 version: 2.1.0
-appVersion: "2.9.0"
+appVersion: "2.9.1"
 icon: https://evertrust.io/media/logo-horizon-blue.png
 home: https://evertrust.io
 sources:

--- a/values.yaml
+++ b/values.yaml
@@ -36,7 +36,7 @@ image:
   ## Horizon image repository
   repository: horizon
   ## Horizon image tag (immutable tags are recommended)
-  tag: 2.9.0
+  tag: 2.9.1
   ## Horizon image flavor (for HSM compatible images)
   flavor: ""
   ## Horizon image pull policy
@@ -716,7 +716,7 @@ upgrade:
     ## Horizon Migration image repository
     repository: horizon-migration
     ## Horizon Migration image tag (immutable tags are recommended)
-    tag: 1.13.0
+    tag: 1.16.0
     ## Horizon Migration image pull policy
     pullPolicy: IfNotPresent
     ## Horizon Migration image pull secrets


### PR DESCRIPTION
🐛 I have created a release beep boop