### PR TITLE
docs(values): clarify keyset must be raw Tink JSON, not pre-base64

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -450,7 +450,10 @@ defaultVault:
   ## Keyset
   ##
   ## A reference to a secret that contains the keyset.
-  ## You should store it (base64-encoded) in a Kubernetes secret and specify the secret details here.
+  ## Store the *raw* Tink JSON keyset (do not base64-encode the JSON yourself):
+  ## JsonKeysetReader expects raw JSON, and Kubernetes already base64-encodes
+  ## secret `data`. Creating it from the file does the right thing, e.g.:
+  ##   kubectl create secret generic horizon-keyset --from-file=keyset=keyset.json
   ##
   ## @ref README.md
   ## @example


### PR DESCRIPTION
Hello, and thanks for the excellent Horizon chart — it's been a pleasure to run.

I'd like to contribute a small documentation improvement. When I first deployed, I read the keyset comment in `values.yaml` ("store it (base64-encoded) in a Kubernetes secret") as "base64-encode the JSON yourself", and stored a base64 string. Because Kubernetes already base64-encodes secret `data`, the keyset ended up double-encoded, so Horizon's `JsonKeysetReader` received base64 text instead of raw JSON and the pod crash-looped on first start.

This PR rewrites just the keyset comment to show the raw-JSON form by example, so the intended way is obvious:

```
kubectl create secret generic horizon-keyset --from-file=keyset=keyset.json
```

No behaviour change — comment only. I left the license comment above untouched, since that one isn't affected.

Thanks again!
