### PR TITLE
fix(allowedHosts): always allow the in-cluster Service FQDN

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -83,6 +83,12 @@ Prints all Horizon allowed hosts.
 */}}
 {{- define "horizon.allowedHosts" }}
 {{- $allowedHosts := list }}
+{{- /* Always allow in-cluster callers that reach Horizon by its Service FQDN.
+       A leading-dot pattern matches the domain and all of its subdomains on any
+       port, so ".<namespace>.svc.<clusterDomain>" covers
+       <release>.<namespace>.svc.<clusterDomain> without hardcoding the release
+       name or the service port. */}}
+{{- $allowedHosts = append $allowedHosts (printf ".%s.svc.%s" .Release.Namespace (.Values.clusterDomain | default "cluster.local")) }}
 {{- if .Values.ingress.enabled -}}
   {{- $allowedHosts = append $allowedHosts .Values.ingress.hostname }}
   {{- range .Values.ingress.extraHosts }}

--- a/tests/allowed_hosts_test.yaml
+++ b/tests/allowed_hosts_test.yaml
@@ -1,0 +1,89 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+suite: allowed hosts
+templates:
+  - deployment.yml
+tests:
+  - it: should always allow the in-cluster Service FQDN even with no ingress and no extra hosts
+    template: deployment.yml
+    release:
+      namespace: horizon-test
+    set:
+      ingress.enabled: false
+      allowedHosts: []
+    asserts:
+      - isKind:
+          of: Deployment
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: HOSTS_ALLOWED.0
+            value: ".horizon-test.svc.cluster.local"
+
+  - it: should build the Service FQDN from a custom clusterDomain
+    template: deployment.yml
+    release:
+      namespace: horizon-test
+    set:
+      clusterDomain: cluster.internal
+      ingress.enabled: false
+      allowedHosts: []
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: HOSTS_ALLOWED.0
+            value: ".horizon-test.svc.cluster.internal"
+
+  - it: should derive the Service FQDN from the release namespace
+    template: deployment.yml
+    release:
+      namespace: another-ns
+    set:
+      ingress.enabled: false
+      allowedHosts: []
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: HOSTS_ALLOWED.0
+            value: ".another-ns.svc.cluster.local"
+
+  - it: should keep the Service FQDN first and append user-provided allowedHosts after it
+    template: deployment.yml
+    release:
+      namespace: horizon-test
+    set:
+      ingress.enabled: false
+      allowedHosts:
+        - "localhost:9000"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: HOSTS_ALLOWED.0
+            value: ".horizon-test.svc.cluster.local"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: HOSTS_ALLOWED.1
+            value: "localhost:9000"
+
+  - it: should keep the Service FQDN first and add the ingress hostname when ingress is enabled
+    template: deployment.yml
+    release:
+      namespace: horizon-test
+    set:
+      ingress.enabled: true
+      ingress.hostname: horizon.example.com
+      allowedHosts: []
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: HOSTS_ALLOWED.0
+            value: ".horizon-test.svc.cluster.local"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: HOSTS_ALLOWED.1
+            value: "horizon.example.com"

--- a/values.yaml
+++ b/values.yaml
@@ -468,9 +468,17 @@ defaultVault:
 ##   secretKey: legacySsvPassword
 legacySsvPassword: {}
 
+## Kubernetes cluster domain. Used to build the in-cluster Service FQDN that is
+## always allowed (see allowedHosts below), so service-to-service calls work
+## out of the box.
+clusterDomain: cluster.local
+
 ## Additional allowed hosts that are whitelisted to access the Horizon UI.
-## Configured ingresses will automatically be added to the list, this should
-## only be used when port forwarding or when an ingress is created manually.
+## Configured ingresses are added automatically, and the in-cluster Service FQDN
+## (.<namespace>.svc.<clusterDomain>, matched on any port) is always allowed.
+## This list is appended to those; use it for port-forwarding or a manually
+## created ingress. Note: Helm replaces (does not merge) arrays, so if you
+## override this value keep localhost:9000 if you still need it.
 ##
 ## @example
 ## allowedHosts:


### PR DESCRIPTION
Hello, and thanks again for the great chart.

I ran into a small problem and wanted to share my solution as a PR. When another in-cluster workload calls Horizon by its Service FQDN (e.g. `horizon.<ns>.svc.cluster.local`), Play's `AllowedHostsFilter` rejects it with "Host not allowed" until the FQDN is added manually — so service-to-service calls don't work out of the box.

This PR adds the in-cluster Service FQDN to the generated allowed hosts automatically. It uses a leading-dot pattern, `.<namespace>.svc.<clusterDomain>`, which — per Play's docs — matches the domain and its subdomains on any port, so it covers `<release>.<namespace>.svc.<clusterDomain>` without hardcoding the release name or the service port. I also added a `clusterDomain` value (default `cluster.local`) and a note that `allowedHosts` is appended to the auto-included hosts (Helm replaces arrays, so it's easy to drop `localhost:9000` by accident when overriding).

Verified with `helm template`:

- default install: `HOSTS_ALLOWED.0=.acme.svc.cluster.local`, `HOSTS_ALLOWED.1=localhost:9000`
- `--set clusterDomain=k8s.lan` renders `.acme.svc.k8s.lan`
- a user-set `allowedHosts` still keeps the in-cluster suffix (appended, not replaced)

Happy to adjust the scoping (namespace-wide vs the exact Service FQDN) if you'd prefer something narrower.
