### PR TITLE
feat: add enableServiceLinks support to deployment

### DIFF
--- a/templates/deployment.yml
+++ b/templates/deployment.yml
@@ -313,6 +313,7 @@ spec:
       {{- if .Values.dnsPolicy }}
       dnsPolicy: {{ .Values.dnsPolicy | quote }}
       {{- end }}
+      enableServiceLinks: {{ .Values.enableServiceLinks }}
       volumes:
         {{- if and (not .Values.persistence.enabled) .Values.analytics.enabled }}
         - name: analytics

--- a/tests/deployment_test.yaml
+++ b/tests/deployment_test.yaml
@@ -96,6 +96,26 @@ tests:
       - failedTemplate:
           errorMessage: horizontalAutoscaler.enabled and externalAutoscaler.enabled are mutually exclusive
 
+  - it: should render enableServiceLinks by default
+    template: deployment.yml
+    asserts:
+      - isKind:
+          of: Deployment
+      - equal:
+          path: spec.template.spec.enableServiceLinks
+          value: true
+
+  - it: should render enableServiceLinks when disabled
+    template: deployment.yml
+    set:
+      enableServiceLinks: false
+    asserts:
+      - isKind:
+          of: Deployment
+      - equal:
+          path: spec.template.spec.enableServiceLinks
+          value: false
+
   - it: should render hpa minReplicas when autoscaling is enabled
     set:
       horizontalAutoscaler.enabled: true

--- a/values.yaml
+++ b/values.yaml
@@ -284,6 +284,11 @@ dnsConfig: {}
 ## @ref https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
 dnsPolicy: ""
 
+## Whether information about services should be injected into pod's environment variable
+##
+## @ref https://kubernetes.io/docs/tutorials/services/connect-applications-service/#accessing-the-service
+enableServiceLinks: true
+
 ## Service configuration
 service:
   ## Kubernetes service type


### PR DESCRIPTION
Allow disabling injection of service info into pod environment variables via .Values.enableServiceLinks (default: true).